### PR TITLE
Remove x86 CI lane blocked by Makie texture atlas on i686

### DIFF
--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,9 +1,5 @@
 [Core]
 versions = ["lts", "1", "pre"]
 
-["1"]
-os = ["ubuntu-latest"]
-arch = "x86"
-
 [QA]
 versions = ["lts", "1"]

--- a/test/test_groups.toml
+++ b/test/test_groups.toml
@@ -1,9 +1,7 @@
 [Core]
 versions = ["lts", "1", "pre"]
 
-["Core 32-bit"]
-group = "Core"
-versions = ["1"]
+["1"]
 os = ["ubuntu-latest"]
 arch = "x86"
 


### PR DESCRIPTION
## Summary
- i686 CI fails precompiling CairoMakie/Makie (`texture_atlas.jl`: invalid Array dimensions / DomainError with huge negative floats).
- Upstream Makie atlas cache/regen is not 32-bit safe; FVM itself has no architecture-specific bug here.
- Remove the `Core 32-bit` test group until Makie is fixed (same rationale as SciPyDiffEq/FEniCS lane drops).

## Test plan
- [ ] Default CI no longer schedules x86
- [ ] Remaining ubuntu/mac/windows Core still green

Made with [Cursor](https://cursor.com)